### PR TITLE
Add MATLAB and Python analysis for laser temperature relationship

### DIFF
--- a/analyze_laser_temperature.m
+++ b/analyze_laser_temperature.m
@@ -1,0 +1,82 @@
+% ANALYZE_LASER_TEMPERATURE Compute 6 mm vs 10 mm laser differences across temperatures.
+%
+%   This script scans all platform test CSV files in the current folder,
+%   calculates the mean laser reading difference between the 6 mm and 10 mm
+%   calibration blocks for each laser channel, and fits a linear trend with
+%   respect to the mean temperature of each dataset.
+%
+%   The reusable logic for computing the differences lives in the helper
+%   function COMPUTE_LASER_LEVEL_DIFFERENCE.
+
+% Configuration
+lowLevel = 6;
+highLevel = 10;
+channelNames = ["laser0", "laser1", "laser2"];
+filePattern = 'platformtest_*C.csv';
+
+% Discover relevant CSV files (ignore backups ending with .bck)
+files = dir(filePattern);
+files = files(~contains({files.name}, '.bck'));
+if isempty(files)
+    error('analyze_laser_temperature:NoFiles', ...
+          'No CSV files matching %s were found.', filePattern);
+end
+
+% Preallocate results container
+nFiles = numel(files);
+results = table('Size', [nFiles, 5], ...
+                'VariableTypes', {'string', 'double', 'double', 'double', 'double'}, ...
+                'VariableNames', {'filename', 'temperature', 'laser0_diff', 'laser1_diff', 'laser2_diff'});
+
+for idx = 1:nFiles
+    fileName = files(idx).name;
+    tbl = readtable(fileName);
+
+    diffs = compute_laser_level_difference(tbl, lowLevel, highLevel, channelNames);
+    meanTemperature = mean(tbl.temperature, 'omitnan');
+
+    results.filename(idx) = string(fileName);
+    results.temperature(idx) = meanTemperature;
+    for chIdx = 1:numel(channelNames)
+        columnName = char(channelNames(chIdx) + "_diff");
+        results.(columnName)(idx) = diffs(chIdx);
+    end
+end
+
+% Sort by temperature for easier interpretation
+results = sortrows(results, 'temperature');
+
+% Display numeric results
+disp('Laser difference (6 mm - 10 mm) versus temperature:');
+disp(results);
+
+% Fit and print linear models for each channel
+fprintf('Linear fits (difference = slope * temperature + intercept):\n');
+coefficients = struct();
+for chIdx = 1:numel(channelNames)
+    columnName = char(channelNames(chIdx) + "_diff");
+    y = results.(columnName);
+    x = results.temperature;
+    p = polyfit(x, y, 1);
+    coefficients.(columnName) = p;
+    fprintf('  %s: slope = %.6f mm/°C, intercept = %.6f mm\n', columnName, p(1), p(2));
+end
+
+% Plot differences vs temperature
+figure('Name', 'Laser difference vs temperature', 'NumberTitle', 'off');
+hold on;
+colors = lines(numel(channelNames));
+for chIdx = 1:numel(channelNames)
+    columnName = char(channelNames(chIdx) + "_diff");
+    plot(results.temperature, results.(columnName), 'o-', 'Color', colors(chIdx,:), ...
+         'DisplayName', sprintf('%s difference', channelNames(chIdx)));
+end
+xlabel('Temperature (°C)');
+ylabel('Laser reading difference (6 mm - 10 mm) [mm]');
+grid on;
+legend('Location', 'best');
+title('Laser channel differences between 6 mm and 10 mm blocks');
+
+% Store the coefficients in the base workspace for further analysis if needed
+assignin('base', 'laser_difference_results', results);
+assignin('base', 'laser_difference_coefficients', coefficients);

--- a/analyze_laser_temperature.py
+++ b/analyze_laser_temperature.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from statistics import mean
+from typing import Iterable, List, Sequence
+
+DATA_PATTERN = "platformtest_*C.csv"
+LOW_LEVEL = 6
+HIGH_LEVEL = 10
+CHANNELS = ("laser0", "laser1", "laser2")
+
+
+def find_data_files(pattern: str) -> List[Path]:
+    paths = sorted(
+        path
+        for path in Path.cwd().glob(pattern)
+        if not path.name.endswith(".bck")
+    )
+    if not paths:
+        raise FileNotFoundError(f"No files matched pattern {pattern!r}")
+    return paths
+
+
+def read_rows(path: Path) -> List[dict]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def compute_channel_means(rows: Iterable[dict], level: float, channels: Sequence[str]) -> List[float]:
+    values = []
+    for row in rows:
+        if float(row["test_level"]) == level:
+            values.append([float(row[channel]) for channel in channels])
+    if not values:
+        raise ValueError(f"No rows found for level {level}.")
+    column_totals = [0.0] * len(channels)
+    for row_values in values:
+        for idx, value in enumerate(row_values):
+            column_totals[idx] += value
+    return [total / len(values) for total in column_totals]
+
+
+def compute_differences(rows: Iterable[dict], low_level: float, high_level: float, channels: Sequence[str]) -> List[float]:
+    low_means = compute_channel_means(rows, low_level, channels)
+    high_means = compute_channel_means(rows, high_level, channels)
+    return [low - high for low, high in zip(low_means, high_means)]
+
+
+def compute_temperature_mean(rows: Iterable[dict]) -> float:
+    temps = [float(row["temperature"]) for row in rows]
+    if not temps:
+        raise ValueError("No temperature readings found.")
+    return mean(temps)
+
+
+def linear_fit(x_values: Sequence[float], y_values: Sequence[float]) -> tuple[float, float]:
+    if len(x_values) != len(y_values):
+        raise ValueError("x and y must have the same length")
+    if len(x_values) < 2:
+        raise ValueError("At least two points are required for a linear fit")
+    x_mean = mean(x_values)
+    y_mean = mean(y_values)
+    numerator = sum((x - x_mean) * (y - y_mean) for x, y in zip(x_values, y_values))
+    denominator = sum((x - x_mean) ** 2 for x in x_values)
+    if denominator == 0:
+        raise ValueError("Cannot compute slope because all x values are identical")
+    slope = numerator / denominator
+    intercept = y_mean - slope * x_mean
+    return slope, intercept
+
+
+def main() -> None:
+    files = find_data_files(DATA_PATTERN)
+    results = []
+    for path in files:
+        rows = read_rows(path)
+        diffs = compute_differences(rows, LOW_LEVEL, HIGH_LEVEL, CHANNELS)
+        temp_mean = compute_temperature_mean(rows)
+        results.append({
+            "filename": path.name,
+            "temperature": temp_mean,
+            "laser0_diff": diffs[0],
+            "laser1_diff": diffs[1],
+            "laser2_diff": diffs[2],
+        })
+
+    results.sort(key=lambda item: item["temperature"])
+
+    header = ("filename", "temperature", "laser0_diff", "laser1_diff", "laser2_diff")
+    print(", ".join(header))
+    for row in results:
+        print(", ".join(
+            f"{row[key]:.9f}" if key != "filename" else row[key]
+            for key in header
+        ))
+
+    print("\nLinear fits (difference = slope * temperature + intercept):")
+    for channel in CHANNELS:
+        column = f"{channel}_diff"
+        slope, intercept = linear_fit(
+            [row["temperature"] for row in results],
+            [row[column] for row in results],
+        )
+        print(f"  {column}: slope = {slope:.9f} mm/°C, intercept = {intercept:.9f} mm")
+
+
+if __name__ == "__main__":
+    main()

--- a/compute_laser_level_difference.m
+++ b/compute_laser_level_difference.m
@@ -1,0 +1,82 @@
+function differences = compute_laser_level_difference(tbl, lowLevel, highLevel, channelNames)
+%COMPUTE_LASER_LEVEL_DIFFERENCE Calculate mean reading differences between two levels.
+%   DIFFERENCES = COMPUTE_LASER_LEVEL_DIFFERENCE(TBL, LOWLEVEL, HIGHLEVEL, CHANNELNAMES)
+%   returns the mean reading at LOWLEVEL minus the mean reading at HIGHLEVEL
+%   for each channel listed in CHANNELNAMES.
+%
+%   TBL           : MATLAB table that contains at least the variables
+%                   'test_level' and every entry in CHANNELNAMES.
+%   LOWLEVEL      : Numeric scalar representing the lower test level (e.g. 6).
+%   HIGHLEVEL     : Numeric scalar representing the higher test level (e.g. 10).
+%   CHANNELNAMES  : String array or cell array of character vectors containing
+%                   the names of the laser channels to analyse.
+%
+%   The function validates that data is available for both levels and throws
+%   an error when one of the levels is missing from the table.
+%
+%   Example
+%       tbl = readtable('platformtest_29-60C.csv');
+%       channelNames = ["laser0", "laser1", "laser2"];
+%       differences = compute_laser_level_difference(tbl, 6, 10, channelNames);
+%
+%   See also READTABLE.
+
+    arguments
+        tbl table
+        lowLevel (1,1) double
+        highLevel (1,1) double
+        channelNames {validateChannelNames(channelNames)}
+    end
+
+    % Ensure channelNames is a string row vector for consistent indexing
+    if iscell(channelNames)
+        channelNames = string(channelNames);
+    else
+        channelNames = channelNames(:)';
+    end
+
+    validateRequiredColumns(tbl, channelNames);
+
+    % Extract rows for the requested levels
+    lowMask = tbl.test_level == lowLevel;
+    highMask = tbl.test_level == highLevel;
+
+    if ~any(lowMask)
+        error('compute_laser_level_difference:MissingLevel', ...
+              'No observations found for level %.3f.', lowLevel);
+    end
+
+    if ~any(highMask)
+        error('compute_laser_level_difference:MissingLevel', ...
+              'No observations found for level %.3f.', highLevel);
+    end
+
+    lowValues = table2array(tbl(lowMask, channelNames));
+    highValues = table2array(tbl(highMask, channelNames));
+
+    lowMeans = mean(lowValues, 1, 'omitnan');
+    highMeans = mean(highValues, 1, 'omitnan');
+
+    differences = lowMeans - highMeans;
+end
+
+function validateRequiredColumns(tbl, channelNames)
+    requiredColumns = ["test_level", channelNames];
+    missing = setdiff(requiredColumns, string(tbl.Properties.VariableNames));
+    if ~isempty(missing)
+        error('compute_laser_level_difference:MissingColumns', ...
+              'The table is missing required columns: %s', strjoin(missing, ', '));
+    end
+end
+
+function validateChannelNames(value)
+% Custom validator that accepts string/cellstr vectors.
+    if ~(isstring(value) || iscellstr(value))
+        error('compute_laser_level_difference:InvalidChannelNames', ...
+              'Channel names must be provided as a string array or cell array of character vectors.');
+    end
+    if numel(value) == 0
+        error('compute_laser_level_difference:EmptyChannelNames', ...
+              'Channel names array must not be empty.');
+    end
+end


### PR DESCRIPTION
## Summary
- add a reusable MATLAB function to compute laser reading differences between 6 mm and 10 mm levels
- add a MATLAB script to aggregate differences across temperature sweeps and fit linear trends
- add a Python script to reproduce the difference and regression calculations from the CSV data

## Testing
- python analyze_laser_temperature.py

------
https://chatgpt.com/codex/tasks/task_e_68d940d3b064832cb1d4a9beb4c7ad61