### PR TITLE
Add MATLAB thermal compensation analysis helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ stack in the measurement path.
    results = temperature_compensation_analysis('.', ...
        'ReferenceTemperature', 31.0, ...
        'SensorDriftOrder', 3, ...
+       'FitEngine', 'manual', ...
        'MaterialStack', struct(
            'aluminumLength', 0.052 ... % customise support length (metres)
        ));
@@ -34,6 +35,12 @@ stack in the measurement path.
    - summarise how each raw laser channel correlates with temperature overall
      and within each `test_level`, so you can see the ~-0.005 mm/°C slopes that
      dominate once the 6 mm and 10 mm baselines are separated.
+
+   Pick `FitEngine` = `'fitlm'` (default) to leverage MATLAB’s `LinearModel`
+   class, or switch to `'manual'` to build the full dummy-coded design matrix
+   explicitly. The manual engine returns the coefficient estimates, standard
+   errors, t-statistics, p-values and 95% confidence bounds along with the raw
+   design matrix so you can inspect every step of the least-squares solution.
 
 3. Inspect `results.summary` for error statistics, review
    `results.temperatureCorrelation` / `results.perLevelTemperature` to confirm
@@ -57,4 +64,11 @@ stack in the measurement path.
   drift (increase `SensorDriftOrder`), or (iii) imperfect thermal equilibrium
   during acquisition. Use the residual plots to diagnose non-linearity or
   hysteresis.
+- When using the manual engine the `results.(channel).model` struct exposes the
+  full design matrix (`DesignMatrix`), dummy-coded level columns, coefficient
+  table and effective degrees of freedom, making it easier to audit how the
+  per-level offsets, mechanical term and sensor-drift polynomials interact.
+  When the MATLAB engine is selected, the original `LinearModel` object is
+  still accessible via `results.(channel).model.Extras` for anyone who prefers
+  MATLAB’s built-in diagnostics.
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ stack in the measurement path.
      met. Setting the `SensorDriftOrder` to ≥2 allows the optical sensor’s
      thermal drift to deviate from pure linearity while staying monotonic over
      the captured temperature range.
+   - summarise how each raw laser channel correlates with temperature overall
+     and within each `test_level`, so you can see the ~-0.005 mm/°C slopes that
+     dominate once the 6 mm and 10 mm baselines are separated.
 
-3. Inspect `results.summary` for error statistics and, if you call the function
-   without an output argument, review the automatically generated diagnostic
-   plots to look for systematic residual structure.
+3. Inspect `results.summary` for error statistics, review
+   `results.temperatureCorrelation` / `results.perLevelTemperature` to confirm
+   the strength of the within-level temperature trends, check
+   `results.dataOverview` for dataset counts and temperature ranges, and if you
+   call the function without an output argument, review the automatically
+   generated diagnostic plots to look for systematic residual structure.
 
 ## Modelling considerations
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Thermal compensation analysis toolkit
+
+This repository aggregates laser displacement measurements from several
+`platformtest_*.csv` files and now includes a MATLAB helper function for
+building temperature-compensation models that respect the mixed-material
+stack in the measurement path.
+
+## MATLAB workflow
+
+1. Start MATLAB in this folder.
+2. Run the analysis function:
+
+   ```matlab
+   results = temperature_compensation_analysis('.', ...
+       'ReferenceTemperature', 31.0, ...
+       'SensorDriftOrder', 3, ...
+       'MaterialStack', struct(
+           'aluminumLength', 0.052 ... % customise support length (metres)
+       ));
+   ```
+
+   The helper will:
+
+   - load every `platformtest_*.csv` file;
+   - compute the expected mechanical expansion from steel (per `test_level`),
+     zirconia and aluminium sections using configurable coefficients of thermal
+     expansion;
+   - fit per-channel linear models that separate level offsets, mechanical
+     expansion and higher-order sensor drift terms; and
+   - print RMS/peak residuals so you can confirm whether the 0.5 µm target is
+     met. Setting the `SensorDriftOrder` to ≥2 allows the optical sensor’s
+     thermal drift to deviate from pure linearity while staying monotonic over
+     the captured temperature range.
+
+3. Inspect `results.summary` for error statistics and, if you call the function
+   without an output argument, review the automatically generated diagnostic
+   plots to look for systematic residual structure.
+
+## Modelling considerations
+
+- The `MaterialStack` struct lets you fine-tune path lengths (in metres) for
+  each material. By default the steel thickness is derived directly from the
+  `test_level` column (interpreted in millimetres), the zirconia clamp length is
+  fixed at 22 mm, and aluminium defaults to 0 so you can decide how much of the
+  support frame is co-linear with the laser axis.
+- Thermal expansion coefficients can be overridden via the
+  `ExpansionCoefficients` option, making it straightforward to test scenarios
+  such as swapping in different alloys or ceramics.
+- Residuals well above the sub-micron requirement typically indicate either
+  (i) incorrect assumptions about material lengths/CTEs, (ii) unmodelled sensor
+  drift (increase `SensorDriftOrder`), or (iii) imperfect thermal equilibrium
+  during acquisition. Use the residual plots to diagnose non-linearity or
+  hysteresis.
+

--- a/temperature_compensation_analysis.m
+++ b/temperature_compensation_analysis.m
@@ -30,9 +30,14 @@ function results = temperature_compensation_analysis(dataDir, varargin)
 %                               zirconiaLength   -> 22e-3 (22 mm)
 %                               aluminumLength   -> 0.052 (52 mm, adjustable)
 %                             Any unspecified field defaults to zero contribution.
+%     'FitEngine'             Choose 'fitlm' (default) for MATLAB's LinearModel or
+%                             'manual' for an explicit least-squares solve that
+%                             returns the design matrix and coefficient statistics.
 %
 %   The function returns a struct with entries for each laser channel:
-%     results.(channel).model           Fitted LinearModel object
+%     results.(channel).model           Struct containing fitted values, residuals,
+%                                      coefficient table and, for 'fitlm', the
+%                                      original LinearModel in `Extras`
 %     results.(channel).residualStats   Table with RMS and peak residuals (in mm)
 %     results.summary                   Overall table of residual metrics
 %
@@ -50,6 +55,7 @@ addParameter(parser, 'ReferenceTemperature', [], @(x) isempty(x) || isscalar(x))
 addParameter(parser, 'SensorDriftOrder', 2, @(x) isscalar(x) && x >= 0 && round(x) == x);
 addParameter(parser, 'ExpansionCoefficients', struct(), @isstruct);
 addParameter(parser, 'MaterialStack', struct(), @isstruct);
+addParameter(parser, 'FitEngine', 'fitlm', @(s) any(strcmpi(s, {'fitlm', 'manual'})));
 parse(parser, dataDir, varargin{:});
 args = parser.Results;
 
@@ -156,8 +162,7 @@ for idx = 1:numel(laserNames)
         formulaTerms = sprintf('%s + Drift%d', formulaTerms, p);
     end
 
-    mdl = fitlm(tblModel, sprintf('Response ~ %s', formulaTerms), ...
-        'CategoricalVars', 'Level', 'DummyVarCoding', 'full');
+    mdl = fit_full_dummy_model(tblModel, args.FitEngine);
 
     residuals = mdl.Residuals.Raw;
     rmsResidual = sqrt(mean(residuals.^2));
@@ -256,6 +261,83 @@ end
 if nargout == 0
     clear results;
 end
+
+end
+
+function mdl = fit_full_dummy_model(tblModel, engine)
+%FIT_FULL_DUMMY_MODEL  Fit model with full dummy-coded levels using chosen engine.
+engine = lower(engine);
+level = tblModel.Level;
+mechanical = tblModel.Mechanical;
+
+driftVars = setdiff(tblModel.Properties.VariableNames, {'Level', 'Mechanical', 'Response'});
+predictorNames = [{'Mechanical'}, driftVars];
+predictorMatrix = tblModel{:, predictorNames};
+
+categoriesLevel = categories(level);
+numLevels = numel(categoriesLevel);
+numObservations = height(tblModel);
+
+dummyMatrix = zeros(numObservations, numLevels);
+for j = 1:numLevels
+    dummyMatrix(:, j) = (level == categoriesLevel{j});
+end
+
+X = [dummyMatrix, predictorMatrix];
+y = tblModel.Response;
+
+levelNames = strcat('Level_', categoriesLevel(:));
+coefNames = [levelNames; predictorNames(:)];
+
+switch engine
+    case 'fitlm'
+        formulaTerms = '-1 + Level';
+        for k = 1:numel(predictorNames)
+            formulaTerms = sprintf('%s + %s', formulaTerms, predictorNames{k});
+        end
+        lm = fitlm(tblModel, sprintf('Response ~ %s', formulaTerms), ...
+            'CategoricalVars', 'Level', 'DummyVarCoding', 'full');
+
+        coefTable = lm.Coefficients(coefNames, {'Estimate', 'SE', 'tStat', 'pValue', 'Lower', 'Upper'});
+        fitted = lm.Fitted;
+        residuals = lm.Residuals.Raw;
+        dof = lm.DFE;
+        residualStdError = sqrt(lm.MSE);
+        details = lm;
+    case 'manual'
+        beta = X \ y;
+        fitted = X * beta;
+        residuals = y - fitted;
+
+        dof = max(numObservations - size(X, 2), 1);
+        sigma2 = sum(residuals.^2) / dof;
+        XtXInv = pinv(X' * X);
+        stdErr = sqrt(diag(XtXInv) * sigma2);
+        tStat = beta ./ stdErr;
+        pValues = 2 * tcdf(-abs(tStat), dof);
+        ciHalfWidth = tinv(0.975, dof) * stdErr;
+
+        coefTable = table(beta, stdErr, tStat, pValues, beta - ciHalfWidth, beta + ciHalfWidth, ...
+            'VariableNames', {'Estimate', 'SE', 'tStat', 'pValue', 'Lower', 'Upper'}, ...
+            'RowNames', coefNames);
+        residualStdError = sqrt(sigma2);
+        details = struct('NormalMatrixInv', XtXInv);
+    otherwise
+        error('Unsupported FitEngine: %s', engine);
+end
+
+mdl = struct();
+mdl.Engine = engine;
+mdl.CoefficientNames = coefNames;
+mdl.Coefficients = coefTable;
+mdl.DesignMatrix = X;
+mdl.NumObservations = numObservations;
+mdl.DegreesOfFreedom = dof;
+mdl.Fitted = fitted;
+mdl.Residuals = table(residuals, 'VariableNames', {'Raw'});
+mdl.ResidualStdError = residualStdError;
+mdl.Response = y;
+mdl.Extras = details;
 
 end
 

--- a/temperature_compensation_analysis.m
+++ b/temperature_compensation_analysis.m
@@ -1,0 +1,205 @@
+function results = temperature_compensation_analysis(dataDir, varargin)
+%TEMPERATURE_COMPENSATION_ANALYSIS  Build thermal compensation models.
+%   RESULTS = TEMPERATURE_COMPENSATION_ANALYSIS(DATADIR) loads all CSV files
+%   in DATADIR whose names start with "platformtest_" and contain the
+%   columns `test_level`, `temperature`, and one or more `laser*` channels.
+%   It fits a stacked-material thermal expansion + sensor drift model for
+%   each laser channel, reports the residual statistics, and (when no output
+%   argument is requested) plots the fit.
+%
+%   The model assumes the measured displacement y can be decomposed into:
+%       y = b(level)                                        ... height offset
+%           + Sum_i (alpha_i * L_i(level) * (T - T_ref))    ... mechanics
+%           + Sum_k c_k * (T - T_ref)^k                     ... sensor drift
+%           + epsilon
+%   where alpha_i are thermal expansion coefficients and L_i are the
+%   effective path lengths of steel, zirconia, aluminium, etc.  The
+%   mechanical term is linear in temperature, while the laser sensor drift
+%   is represented by a polynomial of configurable order.
+%
+%   Optional name-value arguments:
+%     'ReferenceTemperature'  Scalar reference temperature in °C.  Default: mean(T).
+%     'SensorDriftOrder'      Non-negative integer polynomial order (default 2).
+%     'ExpansionCoefficients' Struct with fields `steel`, `zirconia`, `aluminum`.
+%                             Units: 1/°C. Default values (from materials data):
+%                               steel    = 11.5e-6
+%                               zirconia = 10.5e-6
+%                               aluminum = 23e-6
+%     'MaterialStack'         Struct describing path lengths in metres. Fields:
+%                               steelFcn(level)  -> steel length (m), default level*1e-3
+%                               zirconiaLength   -> 22e-3 (22 mm)
+%                               aluminumLength   -> 0.052 (52 mm, adjustable)
+%                             Any unspecified field defaults to zero contribution.
+%
+%   The function returns a struct with entries for each laser channel:
+%     results.(channel).model           Fitted LinearModel object
+%     results.(channel).residualStats   Table with RMS and peak residuals (in mm)
+%     results.summary                   Overall table of residual metrics
+%
+%   Example:
+%     results = temperature_compensation_analysis('.', ...
+%         'ReferenceTemperature', 31.0, ...
+%         'SensorDriftOrder', 3, ...
+%         'MaterialStack', struct('aluminumLength', 0.06));
+%
+
+parser = inputParser;
+parser.FunctionName = mfilename;
+addRequired(parser, 'dataDir', @(x) ischar(x) || isstring(x));
+addParameter(parser, 'ReferenceTemperature', [], @(x) isempty(x) || isscalar(x));
+addParameter(parser, 'SensorDriftOrder', 2, @(x) isscalar(x) && x >= 0 && round(x) == x);
+addParameter(parser, 'ExpansionCoefficients', struct(), @isstruct);
+addParameter(parser, 'MaterialStack', struct(), @isstruct);
+parse(parser, dataDir, varargin{:});
+args = parser.Results;
+
+% Default coefficients of thermal expansion (CTE) in 1/°C
+defaultCTE = struct('steel', 11.5e-6, 'zirconia', 10.5e-6, 'aluminum', 23e-6);
+cte = merge_struct(defaultCTE, args.ExpansionCoefficients);
+
+% Default stack lengths in metres
+defaultStack = struct( ...
+    'steelFcn', @(level) level(:) * 1e-3, ... % interpret test_level as mm thickness
+    'zirconiaLength', 22e-3, ...             % 22 mm zirconia clamp
+    'aluminumLength', 0.0);                  % allow user to override
+stack = merge_struct(defaultStack, args.MaterialStack);
+
+% Collect data
+files = dir(fullfile(dataDir, 'platformtest_*.csv'));
+if isempty(files)
+    error('No CSV files matching platformtest_*.csv found in %s', dataDir);
+end
+
+tbls = cell(numel(files), 1);
+for k = 1:numel(files)
+    tbls{k} = readtable(fullfile(files(k).folder, files(k).name));
+end
+data = vertcat(tbls{:});
+
+requiredColumns = {'test_level', 'temperature'};
+for c = requiredColumns
+    if ~ismember(c{1}, data.Properties.VariableNames)
+        error('Input data must contain column "%s".', c{1});
+    end
+end
+
+laserColumns = startsWith(data.Properties.VariableNames, 'laser');
+laserNames = data.Properties.VariableNames(laserColumns);
+if isempty(laserNames)
+    error('No laser* columns found in the data.');
+end
+
+data = sortrows(data, {'test_level', 'temperature'});
+
+T = data.temperature;
+if isempty(args.ReferenceTemperature)
+    Tref = mean(T, 'omitnan');
+else
+    Tref = args.ReferenceTemperature;
+end
+deltaT = T - Tref;
+
+level = data.test_level;
+steelLength = stack.steelFcn(level);
+
+zirconiaLength = fetch_stack_value(stack, 'zirconiaLength', level);
+alLength = fetch_stack_value(stack, 'aluminumLength', level);
+
+mechanicalSlope_mm_per_deg = ...
+    steelLength * cte.steel * 1e3 + ...
+    zirconiaLength * cte.zirconia * 1e3 + ...
+    alLength * cte.aluminum * 1e3;
+
+mechanicalDelta_mm = mechanicalSlope_mm_per_deg .* deltaT;
+
+catLevel = categorical(level);
+
+% Prepare polynomial terms for sensor drift
+polyOrder = args.SensorDriftOrder;
+driftTerms = zeros(height(data), polyOrder);
+for p = 1:polyOrder
+    driftTerms(:, p) = deltaT.^p;
+end
+
+results = struct();
+summaryRows = [];
+
+for idx = 1:numel(laserNames)
+    channel = laserNames{idx};
+    y = data.(channel);
+
+    tblModel = table(catLevel, mechanicalDelta_mm, 'VariableNames', {'Level', 'Mechanical'});
+    for p = 1:polyOrder
+        tblModel.(sprintf('Drift%d', p)) = driftTerms(:, p);
+    end
+    tblModel.Response = y;
+
+    formulaTerms = ['-1 + Level + Mechanical'];
+    for p = 1:polyOrder
+        formulaTerms = sprintf('%s + Drift%d', formulaTerms, p);
+    end
+
+    mdl = fitlm(tblModel, sprintf('Response ~ %s', formulaTerms));
+
+    residuals = mdl.Residuals.Raw;
+    rmsResidual = sqrt(mean(residuals.^2));
+    peakResidual = max(abs(residuals));
+    results.(channel).model = mdl;
+    results.(channel).residualStats = table(rmsResidual, peakResidual, ...
+        'VariableNames', {'RMS_mm', 'Peak_mm'});
+
+    summaryRows = [summaryRows; {channel, rmsResidual, peakResidual}]; %#ok<AGROW>
+
+    if nargout == 0
+        figure('Name', sprintf('Channel %s', channel));
+        subplot(2,1,1);
+        plot(T, y, 'o'); hold on;
+        plot(T, mdl.Fitted, '.-');
+        xlabel('Temperature (°C)'); ylabel('Laser reading (mm)');
+        title(sprintf('%s: Data vs Model', channel)); legend('Data', 'Model', 'Location', 'best');
+
+        subplot(2,1,2);
+        plot(T, residuals, 'o-'); yline(0, '--k');
+        xlabel('Temperature (°C)'); ylabel('Residual (mm)');
+        title(sprintf('%s: Residuals (RMS = %.4g mm)', channel, rmsResidual));
+    end
+end
+
+results.summary = cell2table(summaryRows, 'VariableNames', {'Channel', 'RMS_mm', 'Peak_mm'});
+
+fprintf('\nThermal compensation summary (mm):\n');
+disp(results.summary);
+
+fprintf('Reference temperature: %.3f °C\n', Tref);
+fprintf('Assumed mechanical slope: %.4g mm/°C\n', mean(mechanicalSlope_mm_per_deg, 'omitnan'));
+
+if nargout == 0
+    clear results;
+end
+
+end
+
+function merged = merge_struct(base, override)
+merged = base;
+fields = fieldnames(override);
+for k = 1:numel(fields)
+    merged.(fields{k}) = override.(fields{k});
+end
+end
+
+function values = fetch_stack_value(stack, fieldName, level)
+if isfield(stack, fieldName)
+    val = stack.(fieldName);
+    if isa(val, 'function_handle')
+        values = val(level);
+    elseif isscalar(val)
+        values = repmat(val, numel(level), 1);
+    elseif numel(val) == numel(level)
+        values = val(:);
+    else
+        error('Field %s must be scalar or length %d.', fieldName, numel(level));
+    end
+else
+    values = zeros(numel(level), 1);
+end
+end

--- a/temperature_compensation_analysis.m
+++ b/temperature_compensation_analysis.m
@@ -114,6 +114,21 @@ mechanicalDelta_mm = mechanicalSlope_mm_per_deg .* deltaT;
 
 catLevel = categorical(level);
 
+uniqueLevels = unique(level);
+numFiles = numel(files);
+numRows = height(data);
+temperatureRange = [min(T, [], 'omitnan'), max(T, [], 'omitnan')];
+levelTemperatureTable = groupsummary(table(level, T), 'level', {'mean', 'std'}, 'T');
+
+results = struct();
+results.dataOverview = struct( ...
+    'numFiles', numFiles, ...
+    'numRows', numRows, ...
+    'temperatureMin', temperatureRange(1), ...
+    'temperatureMax', temperatureRange(2), ...
+    'testLevels', uniqueLevels, ...
+    'levelTemperature', levelTemperatureTable);
+
 % Prepare polynomial terms for sensor drift
 polyOrder = args.SensorDriftOrder;
 driftTerms = zeros(height(data), polyOrder);
@@ -121,8 +136,10 @@ for p = 1:polyOrder
     driftTerms(:, p) = deltaT.^p;
 end
 
-results = struct();
-summaryRows = [];
+perLevelVarNames = {'Channel', 'Level_mm', 'TempCorrelation', 'Slope_mm_per_deg', 'MeanReading_mm'};
+summaryRows = cell(0, 3);
+correlationSummaryRows = cell(0, 3);
+perLevelSummaryRows = cell(0, numel(perLevelVarNames));
 
 for idx = 1:numel(laserNames)
     channel = laserNames{idx};
@@ -139,7 +156,8 @@ for idx = 1:numel(laserNames)
         formulaTerms = sprintf('%s + Drift%d', formulaTerms, p);
     end
 
-    mdl = fitlm(tblModel, sprintf('Response ~ %s', formulaTerms));
+    mdl = fitlm(tblModel, sprintf('Response ~ %s', formulaTerms), ...
+        'CategoricalVars', 'Level', 'DummyVarCoding', 'full');
 
     residuals = mdl.Residuals.Raw;
     rmsResidual = sqrt(mean(residuals.^2));
@@ -148,7 +166,44 @@ for idx = 1:numel(laserNames)
     results.(channel).residualStats = table(rmsResidual, peakResidual, ...
         'VariableNames', {'RMS_mm', 'Peak_mm'});
 
-    summaryRows = [summaryRows; {channel, rmsResidual, peakResidual}]; %#ok<AGROW>
+    summaryRows(end+1, :) = {channel, rmsResidual, peakResidual};
+
+    validAll = isfinite(T) & isfinite(y);
+    if sum(validAll) >= 2
+        overallCorrelation = corr(T(validAll), y(validAll));
+        coeffsAll = polyfit(T(validAll), y(validAll), 1);
+        overallSlope = coeffsAll(1);
+    else
+        overallCorrelation = NaN;
+        overallSlope = NaN;
+    end
+
+    levelCorr = nan(numel(uniqueLevels), 1);
+    levelSlope = nan(numel(uniqueLevels), 1);
+    levelMean = nan(numel(uniqueLevels), 1);
+    for lv = 1:numel(uniqueLevels)
+        mask = level == uniqueLevels(lv);
+        validMask = mask & isfinite(T) & isfinite(y);
+        if sum(validMask) >= 2
+            levelCorr(lv) = corr(T(validMask), y(validMask));
+            coeffs = polyfit(T(validMask), y(validMask), 1);
+            levelSlope(lv) = coeffs(1);
+        end
+        levelMean(lv) = mean(y(mask), 'omitnan');
+    end
+
+    perLevelTable = table(uniqueLevels, levelCorr, levelSlope, levelMean, ...
+        'VariableNames', {'Level_mm', 'TempCorrelation', 'Slope_mm_per_deg', 'MeanReading_mm'});
+
+    results.(channel).temperatureAnalysis = struct( ...
+        'overallCorrelation', overallCorrelation, ...
+        'overallSlope_mm_per_deg', overallSlope, ...
+        'perLevel', perLevelTable);
+
+    correlationSummaryRows(end+1, :) = {channel, overallCorrelation, overallSlope};
+
+    channelColumn = repmat({channel}, height(perLevelTable), 1);
+    perLevelSummaryRows = [perLevelSummaryRows; [channelColumn, table2cell(perLevelTable)]]; %#ok<AGROW>
 
     if nargout == 0
         figure('Name', sprintf('Channel %s', channel));
@@ -167,11 +222,36 @@ end
 
 results.summary = cell2table(summaryRows, 'VariableNames', {'Channel', 'RMS_mm', 'Peak_mm'});
 
+if ~isempty(correlationSummaryRows)
+    results.temperatureCorrelation = cell2table(correlationSummaryRows, ...
+        'VariableNames', {'Channel', 'OverallCorrelation', 'OverallSlope_mm_per_deg'});
+end
+
+if ~isempty(perLevelSummaryRows)
+    results.perLevelTemperature = cell2table(perLevelSummaryRows, ...
+        'VariableNames', perLevelVarNames);
+end
+
 fprintf('\nThermal compensation summary (mm):\n');
 disp(results.summary);
 
 fprintf('Reference temperature: %.3f °C\n', Tref);
 fprintf('Assumed mechanical slope: %.4g mm/°C\n', mean(mechanicalSlope_mm_per_deg, 'omitnan'));
+
+fprintf('Data overview: %d rows from %d files spanning %.3f–%.3f °C.\n', ...
+    numRows, numFiles, temperatureRange(1), temperatureRange(2));
+levelLabels = arrayfun(@(x) sprintf('%.0f', x), uniqueLevels, 'UniformOutput', false);
+fprintf('Test levels present: %s mm\n', strjoin(levelLabels, ', '));
+
+if isfield(results, 'temperatureCorrelation')
+    fprintf('\nRaw temperature vs. laser correlation (all levels combined):\n');
+    disp(results.temperatureCorrelation);
+end
+
+if isfield(results, 'perLevelTemperature')
+    fprintf('Per-level temperature slopes (mm/°C):\n');
+    disp(results.perLevelTemperature);
+end
 
 if nargout == 0
     clear results;


### PR DESCRIPTION
## Summary
- add a MATLAB function that fits thermal-compensation models across the mixed-material stack and reports residuals per laser channel
- document how to run the analysis and tune the material/expansion parameters in a new README

## Testing
- not run (analysis tooling only)


------
https://chatgpt.com/codex/tasks/task_e_68d940d3b064832cb1d4a9beb4c7ad61